### PR TITLE
Add a .nojekyll file to the docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ jobs:
       install:
         pip install -e .[docs]
       script:
-        sphinx-build -a docs/ docs/_build/html
+        - sphinx-build -a docs/ docs/_build/html
+        - touch docs/_build/html/.nojekyll
       env:
         - DOCS_BUILD=t
 deploy:


### PR DESCRIPTION
This teaches GitHub pages to not use Jekyll to build the site, as
using Jekyll will cause the _static directory to disappear.