### PR TITLE
Switch the test runner to Pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -e .[testing]
 # command to run tests
-script:  python setup.py test
+script: pytest
 jobs:
   include:
     - name: docs

--- a/kajiki/tests/test_xml.py
+++ b/kajiki/tests/test_xml.py
@@ -9,7 +9,6 @@ import traceback
 import xml.dom.minidom
 from io import BytesIO
 from unittest import TestCase, main
-from nose import SkipTest
 
 from kajiki import i18n
 from kajiki.template import KajikiSyntaxError
@@ -1051,9 +1050,6 @@ class TestBracketsInExpression(TestCase):
             assert 'Braced expression not terminated' in str(e), e
 
     def test_leading_opening_brace(self):
-        if sys.version_info[:2] == (2, 6):
-            raise SkipTest('Python 2.6 compiler raises a different kind of error')
-
         try:
             XMLTemplate('<x>${{"a", "b"}</x>')
             assert False, 'must raise'

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,7 @@ def content_of(*files):
 import sys
 py_version = sys.version_info[:2]
 
-TEST_DEPENDENCIES = ['babel', 'nose']
-if py_version == (2, 6):
-    TEST_DEPENDENCIES.extend(['importlib'])
+TEST_DEPENDENCIES = ['babel', 'pytest']
 if py_version < (3, 2):
     TEST_DEPENDENCIES.extend(['backports.tempfile'])
 if py_version < (3, 3):
@@ -74,11 +72,11 @@ setup(name='Kajiki',
       include_package_data=True,
       zip_safe=False,
       install_requires=['nine'],
+      python_requires='>=2.7',
       extras_require = {
           'testing': TEST_DEPENDENCIES,
           'docs': ['sphinx'],
       },
-      test_suite='nose.collector',
       entry_points="""
           [console_scripts]
           kajiki = kajiki.__main__:main


### PR DESCRIPTION
Nose has compatibility issues with Python 3.10, and isn't being
updated.  The pytest runner seems to work with the existing tests, so
switch to it.

Additionally, "python setup.py test" is being deprecated too, so get
rid of that.  In the future, we may want to take a look at tox.

Resolves #54.