### PR TITLE
docs: Add table with summary of how the XML directives can be used

### DIFF
--- a/docs/xml-templates.rst
+++ b/docs/xml-templates.rst
@@ -456,6 +456,30 @@ child.id() = <span>mid</span>
 <h6>Footer</h6>
 </div>
 
+Summary of Directives
+=====================
+
+========== ======================  ============================ ==========================================================
+Directive  Usable as an attribute  Usable as a separate element When used as a separate element, requires attributes named
+========== ======================  ============================ ==========================================================
+py:if      ✅                       ✅                            test
+py:else    ✅                       ✅
+py:switch  ❌                       ✅                            test
+py:case    ✅                       ✅                            value
+py:for     ✅                       ✅                            each
+py:def     ✅                       ✅                            function
+py:call    ❌                       ✅                            args, function
+py:include ❌                       ✅                            href
+py:import  ❌                       ✅                            href
+py:with    ✅                       ✅                            vars
+py:attrs   ✅                       ❌
+py:strip   ✅                       ❌
+py:content ✅                       ❌
+py:replace ✅                       ✅                            value
+py:extends ❌                       ✅                            href
+py:block   ✅                       ✅                            name
+========== ======================  ============================ ==========================================================
+
 Built-in functions
 ==================
 


### PR DESCRIPTION
I think the data in the table is accurate (I consulted [here](https://turbogears.readthedocs.io/en/development/turbogears/kajiki-xml-templates.html) and [here](https://genshi.edgewall.org/wiki/Documentation/xml-templates.html) too because they mentioned some info that the existing doc didn't).
