### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/templating-basics.rst
+++ b/docs/templating-basics.rst
@@ -123,7 +123,7 @@ Using a template loader gives two main advantages over directly instantiating
 templates:
 
  * Compiled templates are cached and only re-parsed when the template changes.
- * Several template tags such as `extends`, `import`, and `include` that require knowlege of other templates become enabled.
+ * Several template tags such as `extends`, `import`, and `include` that require knowledge of other templates become enabled.
 
 Using a template loader would look similar to the following::
 

--- a/kajiki/xml_template.py
+++ b/kajiki/xml_template.py
@@ -854,7 +854,7 @@ class _DomTransformer(object):
 
     @classmethod
     def _extract_nodes_leading_and_trailing_spaces(cls, tree):
-        """Extract the leading and traling spaces of TextNodes to
+        """Extract the leading and trailing spaces of TextNodes to
         separate nodes.
 
         This is explicitly intended to make i18n easier, as we don't


### PR DESCRIPTION
There are small typos in:
- docs/templating-basics.rst
- kajiki/xml_template.py

Fixes:
- Should read `trailing` rather than `traling`.
- Should read `knowledge` rather than `knowlege`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md