### PR TITLE
Support Python 3.11

### DIFF
--- a/kajiki/template.py
+++ b/kajiki/template.py
@@ -274,7 +274,7 @@ class _Template(object):
 
 
 def Template(ns):
-    """Creates a new :class:`._Template` subclass from an entity with ``exposed`` functions.
+    """Creates a :class:`._Template` subclass from an entity with ``exposed`` functions.
 
     Kajiki uses classes as containers of the exposed functions for convenience,
     but any object that can have the functions as attributes works.

--- a/kajiki/xml_template.py
+++ b/kajiki/xml_template.py
@@ -73,7 +73,7 @@ def annotate(gen):
 
 
 class _Compiler(object):
-    """Compiles a DOM tree into Intermediate Representation :class:`kajiki.ir.TemplateNode`.
+    """Compiles a DOM tree into IR :class:`kajiki.ir.TemplateNode`.
 
     Intermediate Representation is a tree of nodes that represent
     Python Code that should be generated to execute the template.

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
@@ -60,6 +61,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.4",
+    install_requires=["linetable"],
     extras_require={
         "testing": ["babel", "pytest"],
         "docs": ["sphinx"],

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1223,7 +1223,7 @@ class TestErrorReporting(TestCase):
             except ZeroDivisionError:
                 exn_info = traceback.format_exception(*sys.exc_info())
                 last_line = exn_info[-2]
-                assert "${3/0}" in last_line, last_line
+                assert "${3/0}" in last_line
             else:
                 assert False
 


### PR DESCRIPTION
This adds support for Python 3.11 by leveraging the linetable package.

https://github.com/amol-/linetable was created for Kajiki, it was born as a separate distribution because it has areas for improvement, and by keeping it separate from Kajiki it can continue to evolve without requiring new Kajiki releases.

Fixes https://github.com/jackrosenthal/kajiki/issues/75