### PR TITLE
Fix py:include within a template loaded by py:extends.

### DIFF
--- a/kajiki/ir.py
+++ b/kajiki/ir.py
@@ -1,7 +1,7 @@
 import re
 from itertools import chain
 
-from .util import flattener, gen_name, window
+from .util import default_alias_for, flattener, gen_name, window
 
 
 def generate_python(ir):
@@ -102,12 +102,14 @@ class ImportNode(Node):
     def __init__(self, tpl_name, alias=None):
         super().__init__()
         self.tpl_name = tpl_name
+        if alias is None:
+            alias = default_alias_for(tpl_name)
         self.alias = alias
 
     def py(self):
         yield self.line(
-            "local.__kj__.import_(%r, %r, self.__globals__)"
-            % (self.tpl_name, self.alias)
+            "%s = local.__kj__.import_(%r, %r, self.__globals__)"
+            % (self.alias, self.tpl_name, self.alias)
         )
 
 

--- a/kajiki/loader.py
+++ b/kajiki/loader.py
@@ -2,6 +2,7 @@ import os
 
 import pkg_resources
 
+from .util import default_alias_for
 
 class Loader(object):
     def __init__(self):
@@ -20,7 +21,7 @@ class Loader(object):
         return mod
 
     def default_alias_for(self, name):
-        return os.path.splitext(os.path.basename(name))[0]
+        return default_alias_for(name)
 
     @property
     def load(self):

--- a/kajiki/util.py
+++ b/kajiki/util.py
@@ -1,6 +1,7 @@
 from collections import deque
 from random import randint
 from threading import local
+import os.path
 
 
 def expose(func):
@@ -85,3 +86,7 @@ def window(seq, n=2):
     for item in seq:
         win.append(item)
         yield win
+
+
+def default_alias_for(name):
+    return os.path.splitext(os.path.basename(name))[0]

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1320,5 +1320,23 @@ class TestSyntaxErrorCallingWithTrailingParenthesis(TestCase):
             pass
 
 
+class TestExtendsWithImport(TestCase):
+    def test_extends_with_import(self):
+        loader = MockLoader({
+            'parent.html': XMLTemplate(
+                '<div>'
+                '<py:import href="lib.html"/>'
+                '${lib.foo()}'
+                '</div>'),
+            'lib.html': XMLTemplate(
+                '<div>'
+                '<py:def function="foo()"><b>foo</b></py:def>'
+                '</div>'),
+            'child.html': XMLTemplate('<py:extends href="parent.html"/>')})
+        child = loader.import_('child.html')
+        r = child().render()
+        assert r == '<div><b>foo</b></div>'
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixes https://github.com/jackrosenthal/kajiki/issues/15.

I believe this is the correct fix: `import` adds names to the local scope.